### PR TITLE
add option to skip processing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ usemin src/index.html -d dist -o dist/index.html --htmlmin true --rmlr true
 ```
 --htmlmin - Also minifies the input HTML file (Boolean)
 --rmlr, --removeLivereload - Remove livereload script (Boolean)
+--noprocess - Do not process files, just replace references (Boolean)
 ```
 
 ### Example HTML

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ var argv = require('yargs')
 			default: false,
 			describe: 'Remove livereload script',
 			type: 'boolean'
+		},
+		'noprocess': {
+			default: false,
+			describe: 'Do not process files, just replace references',
+			type: 'boolean'
 		}
 	})
 	.demand(1)
@@ -38,7 +43,7 @@ var getHTML = require('./lib/getHTML');
 var filePath = argv._[0];
 var content = fs.readFileSync(filePath).toString();
 var blocks = getBlocks(argv._[0], content, argv.removeLivereload);
-var process = processBlocks(blocks, argv.dest);
+var process = (argv.noprocess === true) ? true : processBlocks(blocks, argv.dest);
 var output = getHTML(content, blocks, argv.htmlmin);
 
 if (process) {


### PR DESCRIPTION
Just replace references in the HTML file and allow developers to skip processing matched blocks with bundled utilities.

Use case: as a developer, I have custom tasks which handle building. I just need references replaced.
